### PR TITLE
Fixing chapter 5 answers - 3.b.ii, 5.b, 5.c, 5.d

### DIFF
--- a/ch5/3.Rmd
+++ b/ch5/3.Rmd
@@ -15,7 +15,6 @@ variable depending on which observations are included in the training and
 validation sets. (2.) the validation set error rate may tend to overestimate
 the test error rate for the model fit on the entire data set.
 
-ii. LOOCV is a special case of k-fold cross-validation with k = 1. Thus, with
-the largest fold possible, LOOCV is the most computationally intense method,
-ignoring closed-form solutions for linear models fit by least squares). Also, 
-LOOCV has higher variance, but lower bias, than k-fold CV.
+ii. LOOCV is a special case of k-fold cross-validation with k = n. Thus, LOOCV
+is the most computationally intense method since the model must be fit n times.
+Also, LOOCV has higher variance, but lower bias, than k-fold CV.

--- a/ch5/3.html
+++ b/ch5/3.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta http-equiv="x-ua-compatible" content="IE=9" >
 
 <title>Chapter 5: Exercise 3</title>
 
@@ -159,10 +160,9 @@ variable depending on which observations are included in the training and
 validation sets. (2.) the validation set error rate may tend to overestimate
 the test error rate for the model fit on the entire data set.</p>
 
-<p>ii. LOOCV is a special case of k-fold cross-validation with k = 1. Thus, with
-the largest fold possible, LOOCV is the most computationally intense method,
-ignoring closed-form solutions for linear models fit by least squares). Also, 
-LOOCV has higher variance, but lower bias, than k-fold CV.</p>
+<p>ii. LOOCV is a special case of k-fold cross-validation with k = n. Thus, LOOCV
+is the most computationally intense method since the model must be fit n times.
+Also, LOOCV has higher variance, but lower bias, than k-fold CV.</p>
 
 </body>
 

--- a/ch5/3.md
+++ b/ch5/3.md
@@ -15,7 +15,6 @@ variable depending on which observations are included in the training and
 validation sets. (2.) the validation set error rate may tend to overestimate
 the test error rate for the model fit on the entire data set.
 
-ii. LOOCV is a special case of k-fold cross-validation with k = 1. Thus, with
-the largest fold possible, LOOCV is the most computationally intense method,
-ignoring closed-form solutions for linear models fit by least squares). Also, 
-LOOCV has higher variance, but lower bias, than k-fold CV.
+ii. LOOCV is a special case of k-fold cross-validation with k = n. Thus, LOOCV
+is the most computationally intense method since the model must be fit n times.
+Also, LOOCV has higher variance, but lower bias, than k-fold CV.

--- a/ch5/5.Rmd
+++ b/ch5/5.Rmd
@@ -26,11 +26,11 @@ glm.pred = rep("No", dim(Default)[1]/2)
 glm.probs = predict(glm.fit, Default[-train,], type="response")
 glm.pred[glm.probs>.5] = "Yes"
 # iv.
-return(mean(glm.pred != Default[-train,]))
+return(mean(glm.pred != Default[-train,]$default))
 }
 FiveB()
 ```
-58.2% test error rate from validation set approach.
+2.86% test error rate from validation set approach.
 
 ### c
 ```{r}
@@ -38,7 +38,7 @@ FiveB()
 FiveB()
 FiveB()
 ```
-It seems to average around 58% test error rate.
+It seems to average around 2.6% test error rate.
 
 ### d
 ```{r}
@@ -48,9 +48,9 @@ glm.fit = glm(default~income+balance+student, data=Default, family=binomial,
 glm.pred = rep("No", dim(Default)[1]/2)
 glm.probs = predict(glm.fit, Default[-train,], type="response")
 glm.pred[glm.probs>.5] = "Yes"
-mean(glm.pred != Default[-train,])
+mean(glm.pred != Default[-train,]$default)
 ```
-58.1% test error rate, with student dummy variable. Using the validation set
+2.64% test error rate, with student dummy variable. Using the validation set
 approach, it doesn't appear adding the student dummy variable leads to a
 reduction in the test error rate.
 

--- a/ch5/5.html
+++ b/ch5/5.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta http-equiv="x-ua-compatible" content="IE=9" >
 
 <title>Chapter 5: Exercise 5</title>
 
@@ -215,37 +216,37 @@ glm.fit = glm(default ~ income + balance, data = Default, family = binomial)
     glm.probs = predict(glm.fit, Default[-train, ], type = &quot;response&quot;)
     glm.pred[glm.probs &gt; 0.5] = &quot;Yes&quot;
     # iv.
-    return(mean(glm.pred != Default[-train, ]))
+    return(mean(glm.pred != Default[-train, ]$default))
 }
 FiveB()
 </code></pre>
 
-<pre><code>## [1] 0.5816
+<pre><code>## [1] 0.0286
 </code></pre>
 
-<p>58.2% test error rate from validation set approach.</p>
+<p>2.86% test error rate from validation set approach.</p>
 
 <h3>c</h3>
 
 <pre><code class="r">FiveB()
 </code></pre>
 
-<pre><code>## [1] 0.579
+<pre><code>## [1] 0.0236
 </code></pre>
 
 <pre><code class="r">FiveB()
 </code></pre>
 
-<pre><code>## [1] 0.5813
+<pre><code>## [1] 0.028
 </code></pre>
 
 <pre><code class="r">FiveB()
 </code></pre>
 
-<pre><code>## [1] 0.58
+<pre><code>## [1] 0.0268
 </code></pre>
 
-<p>It seems to average around 58% test error rate.</p>
+<p>It seems to average around 2.6% test error rate.</p>
 
 <h3>d</h3>
 
@@ -255,13 +256,13 @@ glm.fit = glm(default ~ income + balance + student, data = Default, family = bin
 glm.pred = rep(&quot;No&quot;, dim(Default)[1]/2)
 glm.probs = predict(glm.fit, Default[-train, ], type = &quot;response&quot;)
 glm.pred[glm.probs &gt; 0.5] = &quot;Yes&quot;
-mean(glm.pred != Default[-train, ])
+mean(glm.pred != Default[-train, ]$default)
 </code></pre>
 
-<pre><code>## [1] 0.5808
+<pre><code>## [1] 0.0264
 </code></pre>
 
-<p>58.1% test error rate, with student dummy variable. Using the validation set
+<p>2.64% test error rate, with student dummy variable. Using the validation set
 approach, it doesn&#39;t appear adding the student dummy variable leads to a
 reduction in the test error rate.</p>
 

--- a/ch5/5.md
+++ b/ch5/5.md
@@ -44,16 +44,16 @@ FiveB = function() {
     glm.probs = predict(glm.fit, Default[-train, ], type = "response")
     glm.pred[glm.probs > 0.5] = "Yes"
     # iv.
-    return(mean(glm.pred != Default[-train, ]))
+    return(mean(glm.pred != Default[-train, ]$default))
 }
 FiveB()
 ```
 
 ```
-## [1] 0.5816
+## [1] 0.0286
 ```
 
-58.2% test error rate from validation set approach.
+2.86% test error rate from validation set approach.
 
 ### c
 
@@ -62,7 +62,7 @@ FiveB()
 ```
 
 ```
-## [1] 0.579
+## [1] 0.0236
 ```
 
 ```r
@@ -70,7 +70,7 @@ FiveB()
 ```
 
 ```
-## [1] 0.5813
+## [1] 0.028
 ```
 
 ```r
@@ -78,10 +78,10 @@ FiveB()
 ```
 
 ```
-## [1] 0.58
+## [1] 0.0268
 ```
 
-It seems to average around 58% test error rate.
+It seems to average around 2.6% test error rate.
 
 ### d
 
@@ -92,14 +92,14 @@ glm.fit = glm(default ~ income + balance + student, data = Default, family = bin
 glm.pred = rep("No", dim(Default)[1]/2)
 glm.probs = predict(glm.fit, Default[-train, ], type = "response")
 glm.pred[glm.probs > 0.5] = "Yes"
-mean(glm.pred != Default[-train, ])
+mean(glm.pred != Default[-train, ]$default)
 ```
 
 ```
-## [1] 0.5808
+## [1] 0.0264
 ```
 
-58.1% test error rate, with student dummy variable. Using the validation set
+2.64% test error rate, with student dummy variable. Using the validation set
 approach, it doesn't appear adding the student dummy variable leads to a
 reduction in the test error rate.
 


### PR DESCRIPTION
Just fixing a few answers in chapter 5:

3.b.ii - LOOCV uses k=n folds, rather than k=1 folds. (See page 181 of the book.)

5.b, 5.c, 5.d - An error in the "return" statement was causing the test error rates to be way off. As a gut check, the "default" variable is "No" 96.67% of the time, so any reasonable strategy would have an error rate of 3.33% or less, which matches my assertions about the test error rates.

Thanks!
Kevin
