### PR TITLE
fix: chapter 3, ex13. fix for calling rnorm with variance instead of …

### DIFF
--- a/ch3/applied.Rmd
+++ b/ch3/applied.Rmd
@@ -408,7 +408,7 @@ suggests that there isn't a relationship between y and $x^2$.
 ----
 ```{r}
 set.seed(1)
-eps1 = rnorm(100, 0, 0.125)
+eps1 = rnorm(100, 0, sqrt(0.125))
 x1 = rnorm(100)
 y1 = -1 + 0.5*x1 + eps1
 plot(x1, y1)
@@ -424,7 +424,7 @@ As expected, the error observed in $R^2$ and $RSE$ decreases considerably.
 ----
 ```{r}
 set.seed(1)
-eps2 = rnorm(100, 0, 0.5)
+eps2 = rnorm(100, 0, sqrt(0.5))
 x2 = rnorm(100)
 y2 = -1 + 0.5*x2 + eps2
 plot(x2, y2)


### PR DESCRIPTION
fix: chapter 3, ex13. fix for calling rnorm with variance instead of sd.
now, last fit’s interval is indeed wider than the first one.

i tried saving and embedding the plot image, but I get a very different plot (same data, but different style). I tried as follows from OSX. i can add the image plot also if you tell me how you save it.
`dev.print(png, 'plot.png', width=1344, height=960)`

ps: how do you make the ch3/applied.html file? is it automatic from executing your R scripts, or you create it manually and embed the plot images manually?
