### PR TITLE
fix pairs error in R version 4.0.2

### DIFF
--- a/ch2/applied.R
+++ b/ch2/applied.R
@@ -1,5 +1,5 @@
 # 8. (a)
-college = read.csv("../data/College.csv")
+college = read.csv("../data/College.csv", stringsAsFactors=TRUE)
 # 8. (b)
 fix(college)
 rownames(college) = college[,1]


### PR DESCRIPTION
In R version 4.0.2, excluding the `stringsAsFactors=TRUE` parameter       
causes errors in subsequent calls to `pairs` and `plot`.                                                                                         

Fixes issues #106  and #111.